### PR TITLE
Remove Jump data to fix map

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Station capacity information comes from [Motivate's](https://www.motivateco.com/
 
 #### JUMP Bikes
 
-JUMP bike data for DC is available on their [DC open data portal](https://dc.jumpmobility.com/opendata) in [GBFS format](https://github.com/NABSA/gbfs).
+JUMP bike data for DC is available in [GBFS format](https://github.com/NABSA/gbfs) from [`https://gbfs.uber.com/v1/dcb/free_bike_status.json`](https://gbfs.uber.com/v1/dcb/free_bike_status.json). Unfortunately this API does not allow for cross-origin resource sharing, so it cannot be used client-side. Follow [issue #7](https://github.com/alulsh/dc-bikeshare-by-neighborhood/issues/7) for any updates. In the mean time, you can use the script in `scripts/jump.js` to fetch the data manually using Node.js.
 
 ### Historical bikeshare services
 

--- a/index.html
+++ b/index.html
@@ -27,19 +27,6 @@
     <div><span style='background-color: #F2F12D'></span>0</div>
   </div>
 
-  <div id='jumpbikes-legend' class='legend' style='display: none;'>
-    <h4>Bikes</h4>
-    <div><span style='background-color: #723122'></span>8</div>
-    <div><span style='background-color: #8B4225'></span>7</div>
-    <div><span style='background-color: #A25626'></span>6</div>
-    <div><span style='background-color: #B86B25'></span>5</div>
-    <div><span style='background-color: #CA8323'></span>4</div>
-    <div><span style='background-color: #DA9C20'></span>3</div>
-    <div><span style='background-color: #E6B71E'></span>2</div>
-    <div><span style='background-color: #EED322'></span>1</div>
-    <div><span style='background-color: #F2F12D'></span>0</div>
-  </div>
-
   <script src='map.js'></script>
 
 </body>

--- a/index.html
+++ b/index.html
@@ -11,10 +11,12 @@
 </head>
 <body>
 
-  <nav id="menu"></nav>
+  <nav id="menu">
+    <a href="#" id="cabibikes">Capital Bikeshare Bikes</a>
+  </nav>
   <div id='map'></div>
 
-  <div id='cabibikes-legend' class='legend' style='display: none;'>
+  <div id='cabibikes-legend' class='legend'>
     <h4>Bikes</h4>
     <div><span style='background-color: #723122'></span>500</div>
     <div><span style='background-color: #8B4225'></span>400</div>

--- a/map.js
+++ b/map.js
@@ -71,7 +71,7 @@ function loadDcNeighborhoods(bikeshareData) {
           data: neighborhood
         },
         layout: {
-          visibility: 'none'
+          visibility: 'visible'
         },
         paint: {
           'fill-color': {
@@ -111,44 +111,6 @@ function loadDcNeighborhoods(bikeshareData) {
     });
   };
 }
-
-const toggles = [
-  ['Capital Bikeshare Bikes','cabibikes']
-];
-
-toggles.forEach(toggle => {
-  let link = document.createElement('a');
-  link.href = '#';
-  link.id = toggle[1];
-  link.textContent = toggle[0];
-
-  link.onclick = function(e) {
-    let clickedLayer = this.id;
-    e.preventDefault();
-    e.stopPropagation();
-
-    let legend = document.getElementById(`${clickedLayer}-legend`);
-    let visibility = map.getLayoutProperty(`${clickedLayer}-1`, 'visibility');
-
-    if (visibility === 'visible') {
-      legend.style.display = 'none';
-      this.className = '';
-      for (let i = 1; i < 47; i++) {
-        map.setLayoutProperty(`${clickedLayer}-${i}`, 'visibility', 'none');
-      }
-    } else {
-      legend.style.display = '';
-      this.className = 'active';
-      for (let i = 1; i < 47; i++) {
-        map.setLayoutProperty(`${clickedLayer}-${i}`, 'visibility', 'visible');
-      }
-    }
-  };
-
-  let layers = document.getElementById('menu');
-  layers.appendChild(link);
-
-});
 
 map.on('load', () => {
 

--- a/scripts/jump.js
+++ b/scripts/jump.js
@@ -2,7 +2,7 @@ const request = require('request');
 const turf = require('@turf/turf');
 
 const dcNeighborhoodData = 'https://opendata.arcgis.com/datasets/f6c703ebe2534fc3800609a07bad8f5b_17.geojson';
-const jumpData = 'https://dc.jumpmobility.com/opendata/free_bike_status.json';
+const jumpData = 'https://gbfs.uber.com/v1/dcb/free_bike_status.json';
 
 function jumpArray(){
   let bikeArray = [];

--- a/styles.css
+++ b/styles.css
@@ -52,20 +52,6 @@ body {
   border: none;
 }
 
-#menu a:hover {
-  background-color: #DCDCDC;
-  color: #404040;
-}
-
-#menu a.active {
-  background-color: #696969;
-  color: #ffffff;
-}
-
-#menu a.active:hover {
-  background: #A9A9A9;
-}
-
 .legend {
   background-color: #fff;
   border-radius: 3px;


### PR DESCRIPTION
This PR fixes the map for this project. Uber acquired JUMP, which meant that their API moved from `dc.jumpmobility.com` to `gbfs.uber.com.` Unfortunately, this new Uber endpoint does not allow for cross-origin resource sharing, so it can no longer be used client-side in this project (https://github.com/alulsh/dc-bikeshare-by-neighborhood/issues/7).

This project now only displays Capital Bikeshare data.

Breakdown of changes:
* Updates API endpoint URL in `scripts/jump.js` from `https://dc.jumpmobility.com/opendata/free_bike_status.json` to `https://gbfs.uber.com/v1/dcb/free_bike_status.json`
* Removes Jump API from `index.html` and `map.js` due to client-side CORS error
* Removes interactivity and visibility selector for data sets
* Loads Capital Bikeshare data by default
* Updates `README.md` with a note about CORS error with the Jump API