### PR TITLE
Upgrades Mapbox GL JS, Turf, and light style

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
   <meta charset='utf-8' />
   <title>DC bikeshare bikes per neighborhood</title>
   <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
-  <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.44.0/mapbox-gl.js'></script>
-  <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.44.0/mapbox-gl.css' rel='stylesheet' />
+  <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.6.1/mapbox-gl.js'></script>
+  <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.6.1/mapbox-gl.css' rel='stylesheet' />
   <script src="https://cdn.jsdelivr.net/npm/@turf/turf@5/turf.min.js"></script>
   <link rel="stylesheet" type="text/css" href="styles.css">
 </head>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
   <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.6.1/mapbox-gl.js'></script>
   <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.6.1/mapbox-gl.css' rel='stylesheet' />
-  <script src="https://cdn.jsdelivr.net/npm/@turf/turf@5/turf.min.js"></script>
+  <script src="https://npmcdn.com/@turf/turf@5.1.6/turf.min.js"></script>
   <link rel="stylesheet" type="text/css" href="styles.css">
 </head>
 <body>

--- a/map.js
+++ b/map.js
@@ -4,7 +4,7 @@ mapboxgl.accessToken = 'pk.eyJ1IjoiYWx1bHNoIiwiYSI6ImY0NDBjYTQ1NjU4OGJmMDFiMWQ1Y
 
 let map = new mapboxgl.Map({
   container: 'map',
-  style: 'mapbox://styles/mapbox/light-v9',
+  style: 'mapbox://styles/mapbox/light-v10',
   center: [-77.04, 38.89],
   zoom: 10.60
 });


### PR DESCRIPTION
* Upgrades Mapbox GL JS from v0.44.0 to v1.6.1
* Upgrades Turf from v5 to v5.1.6, switch CDN provider to recommended on https://turfjs.org/getting-started
* Upgrades from light-v9 Mapbox style to latest light-v10